### PR TITLE
docker login on circle for develop branch

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -37,5 +37,6 @@ deployment:
     branch: develop
     commands:
       - tests/build_tool.sh
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS quay.io
       - docker push quay.io/eris/eris-cm
       - docs/build.sh


### PR DESCRIPTION
- allows `docker push` to not fail because of no authentication