### PR TITLE
 update use of [chains new --dir] => [chains start --init-dir]

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -201,7 +201,7 @@ run_test(){
     return 1
   fi
   dir_to_use=$chains_dir/$uuid/$direct
-  eris chains new $uuid --dir $uuid/$direct
+  eris chains start $uuid --init-dir $uuid/$direct
   if [ $? -ne 0 ]
   then
     test_exit=1

--- a/tests/test_stacktests_jenkins.sh
+++ b/tests/test_stacktests_jenkins.sh
@@ -141,7 +141,7 @@ run_test(){
   echo "Running test ..."
   dir_to_use=$chains_dir/$uuid/$direct
   echo "New-ing chain from $dir_to_use"
-  eris chains new $uuid --dir $uuid/$direct
+  eris chains start $uuid --init-dir $uuid/$direct
   if [ $? -ne 0 ]
   then
     test_exit=1


### PR DESCRIPTION
- required for https://github.com/eris-ltd/eris-cli/pull/932
- since [chains new] is being kept as a deprecated command, tests should be triggered once 932 is merged and pass before merging this PR